### PR TITLE
Update set_game_path.cmd

### DIFF
--- a/tools/set_game_path.cmd
+++ b/tools/set_game_path.cmd
@@ -1,9 +1,9 @@
 @echo off
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: This script sets the environmental variable CDDA_PATH to either:
+:: This script sets the environmental variable CTLG_PATH to either:
 :: - the first positional argument or
 ::   (also supports drag & drop ofthe game folder ontothe script file)
-:: - the current working directory it it is a valid CDDA game directory or
+:: - the current working directory it it is a valid CTLG game directory or
 :: - a path entered by the user upon prompt
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -34,8 +34,8 @@ if /i [%path_arg%] NEQ [] (
 )
 
 if exist "%CD%\gfx" (
-    if exist "%CD%\cataclysm-tiles.exe" (
-        echo Detected CDDA game directory at %CD%
+    if exist "%CD%\cataclysm-tlg-tiles.exe" (
+        echo Detected CTLG game directory at %CD%
         set path_arg=%CD%&& goto :skip_interactive
     )
 )
@@ -55,19 +55,19 @@ if not exist "%path_arg%" (
 )
 
 if not exist "%path_arg%\gfx" (
-    echo ERROR: Directory "%path_arg%" is not a valid CDDA game directory! && goto stop
+    echo ERROR: Directory "%path_arg%" is not a valid CTLG game directory! && goto stop
 )
-if not exist "%path_arg%\cataclysm-tiles.exe" (
-    echo ERROR: Directory "%path_arg%" is not a valid CDDA game directory! && goto stop
+if not exist "%path_arg%\cataclysm-tlg-tiles.exe" (
+    echo ERROR: Directory "%path_arg%" is not a valid CTLG game directory! && goto stop
 )
 
 if /i [%is_temp%] EQU [YES] (
-    echo Setting cdda path to "%path_arg%", temporarily
-    SET CDDA_PATH=%path_arg%
+    echo Setting ctlg path to "%path_arg%", temporarily
+    SET CTLG_PATH=%path_arg%
 ) else (
-    echo Setting cdda path "%path_arg%", permanently
+    echo Setting ctlg path "%path_arg%", permanently
     echo Reboot required
-    SETX CDDA_PATH %path_arg%
+    SETX CTLG_PATH %path_arg%
 )
 
 if /i [%silent%] NEQ [YES] (


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
Fix when updtset.cmd calls set_game_path.cmd (when variable the_game_dir is not assigned a path)
#### Content of the change
If the variable for the game folder is not assigned, then set_game_path.cmd is called. It used to check for the file cataclysm-tiles.exe, but since CTLG uses cataclysm-tlg-tiles.exe this file needed to be updated as well.
<!-- Explain what does this pull request contain. -->

#### Testing
Tested by executing updtset.cmd
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Executing updtset.cmd with/without providing the variable the_game_dir with the game folder path (release version or catapult version) should now work.