### PR TITLE
[MSX] Add JSON For Ceramic Plate and Jian

### DIFF
--- a/gfx/MShockXotto+/pngs_small_20x20/items/ceramic_plate.json
+++ b/gfx/MShockXotto+/pngs_small_20x20/items/ceramic_plate.json
@@ -1,0 +1,7 @@
+[
+{
+  "id": ["ceramic_plate"],
+  "fg": "ceramic_plate",
+  "bg": []
+}
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/character/overlay/wielded/overlay_wielded_jian.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/character/overlay/wielded/overlay_wielded_jian.json
@@ -1,0 +1,1 @@
+{"id": "overlay_wielded_jian", "fg": ["overlay_wielded_jian"], "rotates": false, "bg": []}


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Didn't think these were needed first time, but they're used in some looks_like's causing them not to appear like they should on their normal item.

#### Content of the change

Adds json files for jian overlay and ceramic plate

#### Testing
<img width="496" height="517" alt="image" src="https://github.com/user-attachments/assets/7c13a4de-bf69-4701-a502-f77bd8a41126" />


#### Additional information
