### PR TITLE
Ignore files created by backport script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1534,3 +1534,6 @@ tools/venv/lib/python3.12/site-packages/pip/_internal/cli/__init__.py
 tools/venv/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py
 tools/venv/lib/python3.12/site-packages/pip/_internal/cli/base_command.py
 tools/venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/caches/file_cache.py
+
+dda-backport-tracked-pr
+dda-backports


### PR DESCRIPTION
#### Summary

There is a backport script ([code](https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/f046f0edb779a90d6576a8db81acfd8de9451d69/tools/dda-backport.sh#L61-L63)) that supports the tiles repo but likes to leave behind a file tracking what PR you ran it on ([code](https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0cedf26d4ca12acba6412a65c6728556addbafa3/tools/dda-backport.sh#L158)). We should ignore it just like the main repo ([code](https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0cedf26d4ca12acba6412a65c6728556addbafa3/.gitignore#L254-L255)).

#### Content of the change

Adds a few lines to `.gitignore`

#### Testing

N/A

#### Additional information

N/A