### PR TITLE
Fix treetops once and for good

### DIFF
--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop" ], "fg": [ "t_tree" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_season_summer" ], "fg": [ "t_tree" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_season_autumn" ], "fg": [ "t_tree_season_autumn" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_season_winter" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_dead.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_dead.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_dead" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_dead_season_summer" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_dead_season_autumn" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_dead_season_winter" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_deadpine.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_deadpine.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_deadpine" ], "fg": [ "t_tree_deadpine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_deadpine_season_summer" ], "fg": [ "t_tree_deadpine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_deadpine_season_autumn" ], "fg": [ "t_tree_deadpine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_deadpine_season_winter" ], "fg": [ "t_tree_deadpine" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_evergreen.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_evergreen.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_evergreen" ], "fg": [ "t_tree_pine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_evergreen_season_summer" ], "fg": [ "t_tree_pine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_evergreen_season_autumn" ], "fg": [ "t_tree_pine" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_evergreen_season_winter" ], "fg": [ "t_tree_pine_season_winter" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_fruit.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_fruit.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_fruit" ], "fg": [ "t_tree_apple_harvested" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_fruit_season_summer" ], "fg": [ "t_tree_apple_harvested" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_fruit_season_autumn" ], "fg": [ "t_tree_apple_harvested" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_fruit_season_winter" ], "fg": [ "t_tree_apple_harvested_season_winter" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_hickory.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_hickory.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_hickory" ], "fg": [ "t_tree_hickory" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_hickory_season_summer" ], "fg": [ "t_tree_hickory" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_hickory_season_autumn" ], "fg": [ "t_tree_hickory_season_autumn" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_hickory_season_winter" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_maple.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_maple.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_maple" ], "fg": [ "t_tree_maple" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_maple_season_summer" ], "fg": [ "t_tree_maple" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_maple_season_autumn" ], "fg": [ "t_tree_maple" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_maple_season_winter" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_nut.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_nut.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_nut" ], "fg": [ "t_tree_hazelnut" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_nut_season_summer" ], "fg": [ "t_tree_hazelnut" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_nut_season_autumn" ], "fg": [ "t_tree_hazelnut_harvested" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_nut_season_winter" ], "fg": [ "t_tree_dead" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_willow.json
+++ b/gfx/MShockXotto+/pngs_large_64x80/terrain/t_treetop_willow.json
@@ -1,6 +1,0 @@
-[
-{"id": ["t_treetop_willow" ], "fg": [ "t_tree_willow" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_willow_season_summer" ], "fg": [ "t_tree_willow" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_willow_season_autumn" ], "fg": [ "t_tree_willow" ], "bg": ["t_open_air_64x80"] },
-{"id": ["t_treetop_willow_season_winter" ], "fg": [ "t_tree_willow_season_winter" ], "bg": ["t_open_air_64x80"] }
-]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_treetop_dead.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_treetop_dead.json
@@ -1,0 +1,6 @@
+[
+{"id": ["t_treetop_dead" ], "fg": [ "" ], "bg": ["t_open_air"] },
+{"id": ["t_treetop_dead_season_summer" ], "fg": [ "" ], "bg": ["t_open_air"] },
+{"id": ["t_treetop_dead_season_autumn" ], "fg": [ "" ], "bg": ["t_open_air"] },
+{"id": ["t_treetop_dead_season_winter" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_deadpine.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_deadpine.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_deadpine" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_evergreen.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_evergreen.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_evergreen" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_fruit.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_fruit.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_fruit" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_hickory.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_hickory.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_hickory" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_maple.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_maple.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_maple" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_nut.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_nut.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_nut" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_willow.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/treetops/t_treetop_willow.json
@@ -1,0 +1,3 @@
+[
+{"id": ["t_treetop_willow" ], "fg": [ "" ], "bg": ["t_open_air"] }
+]


### PR DESCRIPTION
#### Summary
Fix treetops once and for good

#### Content of the change
Treetops were causing no end of problems because the code that draws 32x32 tiles is totally different from the code that draws larger tiles, and the transparency looked wrong no matter what because it was handled completely differently. Therefore the solution is just to make treetops not have any tile at all!

<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
